### PR TITLE
Fixup fetch time setting on cache entry

### DIFF
--- a/src/fetch/service.rs
+++ b/src/fetch/service.rs
@@ -280,7 +280,7 @@ async fn fetch_if_older(
             ServiceResult::Ok(ConfigResult::new(entry.config.clone(), entry.fetch_time))
         }
         FetchResponse::NotModified => {
-            entry.fetch_time = Utc::now();
+            entry.set_fetch_time(Utc::now());
             options
                 .cache()
                 .write(&state.cache_key, entry.cache_str.as_str());
@@ -288,7 +288,7 @@ async fn fetch_if_older(
         }
         FetchResponse::Failed(err, transient) => {
             if !transient && !entry.is_empty() {
-                entry.fetch_time = Utc::now();
+                entry.set_fetch_time(Utc::now());
                 options
                     .cache()
                     .write(&state.cache_key, entry.cache_str.as_str());


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR fixes the fetch time setting on the cache entry that we use when we only update the fetch time before updating the cache.

### Related issues (only if applicable)

n/a

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
