### PR TITLE
Add fmt::Debug impl to Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/configcat/rust-sdk"
 documentation = "https://configcat.com/docs/sdk-reference/rust"
 keywords = ["configcat", "feature-flag", "feature-toggle"]
 license = "MIT"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 [dependencies]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -6,6 +6,7 @@ use crate::modes::PollingMode;
 use crate::r#override::{FlagOverrides, OptionalOverrides};
 use crate::{Client, ConfigCache, OverrideBehavior, OverrideDataSource, User};
 use std::borrow::Borrow;
+use std::fmt::{Debug, Formatter};
 use std::time::Duration;
 
 pub struct Options {
@@ -55,6 +56,21 @@ impl Options {
 
     pub(crate) fn default_user(&self) -> &Option<User> {
         &self.default_user
+    }
+}
+
+impl Debug for Options {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Options")
+            .field("sdk_key", &self.sdk_key)
+            .field("offline", &self.offline)
+            .field("base_url", &self.base_url)
+            .field("data_governance", &self.data_governance)
+            .field("http_timeout", &self.http_timeout)
+            .field("overrides", &self.overrides)
+            .field("polling_mode", &self.polling_mode)
+            .field("default_user", &self.default_user)
+            .finish()
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,6 +9,7 @@ use crate::{ClientCacheState, ClientError, Setting, User};
 use log::{error, warn};
 use std::any::type_name;
 use std::collections::HashMap;
+use std::fmt::{Debug, Formatter};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::time::timeout;
@@ -543,5 +544,14 @@ impl Client {
     fn set_def_user(&self, user: Option<User>) {
         let mut def_user = self.default_user.lock().unwrap();
         *def_user = user
+    }
+}
+
+impl Debug for Client {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Client")
+            .field("options", &self.options)
+            .field("default_user", &self.default_user)
+            .finish()
     }
 }

--- a/src/modes.rs
+++ b/src/modes.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 /// let lazy_load = PollingMode::LazyLoad(Duration::from_secs(60));
 /// let manual = PollingMode::Manual;
 /// ```
+#[derive(Debug)]
 pub enum PollingMode {
     /// Specifies how frequently the locally cached config will be refreshed by fetching the latest version from the remote server.
     ///

--- a/src/override/behavior.rs
+++ b/src/override/behavior.rs
@@ -1,4 +1,5 @@
 /// Specifies the behaviors for flag overrides.
+#[derive(Debug)]
 pub enum OverrideBehavior {
     /// When evaluating values, the SDK will not use feature flags & settings from the ConfigCat CDN, but it will use
     /// all feature flags & settings that are loaded from local-override sources.

--- a/src/override/mod.rs
+++ b/src/override/mod.rs
@@ -1,5 +1,6 @@
 use crate::{OverrideBehavior, OverrideDataSource};
 use std::borrow::Borrow;
+use std::fmt::{Debug, Formatter};
 
 pub mod behavior;
 pub mod file;
@@ -35,5 +36,13 @@ impl OptionalOverrides for Option<FlagOverrides> {
             return matches!(ov.behavior, OverrideBehavior::LocalOnly);
         }
         false
+    }
+}
+
+impl Debug for FlagOverrides {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FlagOverrides")
+            .field("behavior", &self.behavior)
+            .finish()
     }
 }

--- a/src/user.rs
+++ b/src/user.rs
@@ -70,7 +70,7 @@ pub enum UserValue {
 ///
 /// assert_eq!("user-id", user[User::IDENTIFIER].to_string().as_str());
 /// ```
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Clone, Debug)]
 pub struct User {
     attributes: HashMap<String, UserValue>,
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -100,6 +100,13 @@ async fn get_all_values_with_user() {
     assert!(values["disabledFeature"].as_bool().unwrap());
 }
 
+#[tokio::test]
+async fn dbg() {
+    let client = client_builder().build().unwrap();
+
+    assert!(format!("{client:?}").starts_with("Client { options: Options { sdk_key: "));
+}
+
 fn client_builder() -> ClientBuilder {
     Client::builder("local").overrides(Box::new(FileDataSource::new("tests/data/test_json_complex.json").unwrap()), LocalOnly)
 }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -104,7 +104,8 @@ async fn get_all_values_with_user() {
 async fn dbg() {
     let client = client_builder().build().unwrap();
 
-    let exp = r#"Client { options: Options { sdk_key: "local", offline: false, base_url: None, data_governance: Global, http_timeout: 30s, overrides: Some(FlagOverrides { behavior: LocalOnly }), polling_mode: AutoPoll(60s), default_user: None }, default_user: Mutex { data: None, poisoned: false, .. } }"#;
+    let exp =
+        r#"Client { options: Options { sdk_key: "local", offline: false, base_url: None, data_governance: Global, http_timeout: 30s, overrides: Some(FlagOverrides { behavior: LocalOnly }), polling_mode: AutoPoll(60s), default_user: None }, default_user: Mutex { data: None, poisoned: false, .. } }"#;
     assert_eq!(format!("{client:?}"), exp);
 }
 

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -104,7 +104,8 @@ async fn get_all_values_with_user() {
 async fn dbg() {
     let client = client_builder().build().unwrap();
 
-    assert!(format!("{client:?}").starts_with("Client { options: Options { sdk_key: "));
+    let exp = r#"Client { options: Options { sdk_key: "local", offline: false, base_url: None, data_governance: Global, http_timeout: 30s, overrides: Some(FlagOverrides { behavior: LocalOnly }), polling_mode: AutoPoll(60s), default_user: None }, default_user: Mutex { data: None, poisoned: false, .. } }"#;
+    assert_eq!(format!("{client:?}"), exp);
 }
 
 fn client_builder() -> ClientBuilder {


### PR DESCRIPTION
### Describe the purpose of your pull request

This PR adds a `std::fmt::Debug` implementation for `Client` that formats its internal state.

### Related issues (only if applicable)

#3 

### Requirement checklist (only if applicable)

- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
