### PR TITLE
Replace mutex in config service with atomic config entry / semaphore

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,9 @@ arc-swap = "1.7.1"
 mockito = "1.2.0"
 serde_yaml = "0.9.33"
 tokio = { version = "1.17.0", features = ["rt-multi-thread"] }
-rand = "0.8.5"
+rand = "0.9.1"
+criterion = { version = "0.6.0", features = ["async_tokio"] }
+
+[[bench]]
+name = "client_benchmark"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ repository = "https://github.com/configcat/rust-sdk"
 documentation = "https://configcat.com/docs/sdk-reference/rust"
 keywords = ["configcat", "feature-flag", "feature-toggle"]
 license = "MIT"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 
 [dependencies]
@@ -24,6 +24,7 @@ sha1 = "0.10"
 sha2 = "0.10"
 base16ct = { version = "0.2", features = ["alloc"] }
 semver = "1.0"
+arc-swap = "1.7.1"
 
 [dev-dependencies]
 mockito = "1.2.0"

--- a/benches/client_benchmark.rs
+++ b/benches/client_benchmark.rs
@@ -42,7 +42,7 @@ fn get_value_bench(c: &mut Criterion) {
             for _ in 0..200 {
                 let cl = client.clone();
                 handles.push(tokio::spawn(async move {
-                    cl.get_value("isAwesomeFeatureEnabled", false, None).await
+                    cl.get_value("testKey", false, None).await
                 }));
             }
             for handle in handles {

--- a/benches/client_benchmark.rs
+++ b/benches/client_benchmark.rs
@@ -42,8 +42,7 @@ fn get_value_bench(c: &mut Criterion) {
             for _ in 0..200 {
                 let cl = client.clone();
                 handles.push(tokio::spawn(async move {
-                    let v = cl.get_value("testKey", false, None).await;
-                    println!("{v}")
+                    cl.get_value("testKey", false, None).await;
                 }));
             }
             for handle in handles {

--- a/benches/client_benchmark.rs
+++ b/benches/client_benchmark.rs
@@ -1,0 +1,64 @@
+use chrono::{DateTime, Utc};
+use configcat::{Client, ConfigCache, PollingMode};
+use criterion::Criterion;
+use criterion::{criterion_group, criterion_main};
+use std::sync::Arc;
+use tokio::runtime::Runtime;
+
+struct SingleValueCache {
+    value: String,
+}
+
+impl SingleValueCache {
+    pub fn new(val: String) -> Self {
+        Self { value: val }
+    }
+}
+
+impl ConfigCache for SingleValueCache {
+    fn read(&self, _: &str) -> Option<String> {
+        Some(self.value.clone())
+    }
+    fn write(&self, _: &str, _: &str) {}
+}
+
+fn get_value_bench(c: &mut Criterion) {
+    let client = Arc::new(
+        Client::builder("PKDVCLf-Hq-h-kCzMp-L7Q/HhOWfwVtZ0mb30i9wi17GQ")
+            .polling_mode(PollingMode::Manual)
+            // We benchmark on a cache to bypass the first HTTP request which
+            // heavily influences the measurements.
+            .cache(Box::new(SingleValueCache::new(construct_cache_payload(
+                "test",
+                Utc::now(),
+                "tag",
+            ))))
+            .build()
+            .unwrap(),
+    );
+    c.bench_function("get_value", |b| {
+        b.to_async(Runtime::new().unwrap()).iter(|| async {
+            let mut handles = Vec::new();
+            for _ in 0..200 {
+                let cl = client.clone();
+                handles.push(tokio::spawn(async move {
+                    cl.get_value("isAwesomeFeatureEnabled", false, None).await
+                }));
+            }
+            for handle in handles {
+                handle.await.unwrap();
+            }
+        });
+    });
+}
+
+fn construct_cache_payload(val: &str, time: DateTime<Utc>, etag: &str) -> String {
+    time.timestamp_millis().to_string() + "\n" + etag + "\n" + &construct_json_payload(val)
+}
+
+fn construct_json_payload(val: &str) -> String {
+    format!(r#"{{"f": {{"testKey":{{"t":1,"v":{{"s": "{val}"}}}}}}, "s": []}}"#)
+}
+
+criterion_group!(benches, get_value_bench);
+criterion_main!(benches);

--- a/benches/client_benchmark.rs
+++ b/benches/client_benchmark.rs
@@ -29,7 +29,7 @@ fn get_value_bench(c: &mut Criterion) {
             // We benchmark on a cache to bypass the first HTTP request which
             // heavily influences the measurements.
             .cache(Box::new(SingleValueCache::new(construct_cache_payload(
-                "test",
+                true,
                 Utc::now(),
                 "tag",
             ))))
@@ -42,7 +42,8 @@ fn get_value_bench(c: &mut Criterion) {
             for _ in 0..200 {
                 let cl = client.clone();
                 handles.push(tokio::spawn(async move {
-                    cl.get_value("testKey", false, None).await
+                    let v = cl.get_value("testKey", false, None).await;
+                    println!("{v}")
                 }));
             }
             for handle in handles {
@@ -52,12 +53,12 @@ fn get_value_bench(c: &mut Criterion) {
     });
 }
 
-fn construct_cache_payload(val: &str, time: DateTime<Utc>, etag: &str) -> String {
+fn construct_cache_payload(val: bool, time: DateTime<Utc>, etag: &str) -> String {
     time.timestamp_millis().to_string() + "\n" + etag + "\n" + &construct_json_payload(val)
 }
 
-fn construct_json_payload(val: &str) -> String {
-    format!(r#"{{"f": {{"testKey":{{"t":1,"v":{{"s": "{val}"}}}}}}, "s": []}}"#)
+fn construct_json_payload(val: bool) -> String {
+    format!(r#"{{"f": {{"testKey":{{"t":0,"v":{{"b": {val}}}}}}}, "s": []}}"#)
 }
 
 criterion_group!(benches, get_value_bench);

--- a/src/fetch/service.rs
+++ b/src/fetch/service.rs
@@ -280,7 +280,7 @@ async fn fetch_if_older(
 
     // When an unblocked caller reaches this, we most likely have the latest
     // entry set by the fetching caller. If we didn't, then the entry might have
-    // been overwritten by one of the blocked callers from the cache right after
+    // been overwritten from the cache by one of the blocked callers right after
     // the fetching caller saved it. In this case, we'll do another fetch.
     let entry = state.cached_entry.load();
     if entry.fetch_time > threshold {

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -63,17 +63,18 @@ impl ConfigEntry {
         Utc::now() - duration > self.fetch_time
     }
 
-    pub fn set_fetch_time(&mut self, fetch_time: DateTime<Utc>) {
-        let Some(time_index) = self.cache_str.find('\n') else {
-            return;
-        };
+    pub fn with_fetch_time(&self, fetch_time: DateTime<Utc>) -> Option<ConfigEntry> {
+        let time_index = self.cache_str.find('\n')?;
         let without_time = &self.cache_str[time_index + 1..];
-        let Some(etag_index) = without_time.find('\n') else {
-            return;
-        };
+        let etag_index = without_time.find('\n')?;
         let config_json = &self.cache_str[time_index + 1 + etag_index + 1..];
-        self.fetch_time = fetch_time;
-        self.cache_str = generate_cache_str(fetch_time, &self.etag, config_json);
+        let cache_str = generate_cache_str(fetch_time, &self.etag, config_json);
+        Some(ConfigEntry {
+            config: self.config.clone(),
+            cache_str,
+            etag: self.etag.clone(),
+            fetch_time,
+        })
     }
 }
 
@@ -539,14 +540,14 @@ mod model_tests {
     #[test]
     fn set_fetch_time() {
         let payload = format!("1686756435844\ntest-etag\n{CONFIG_JSON}");
-        let mut entry = entry_from_cached_json(payload.as_str()).unwrap();
+        let entry = entry_from_cached_json(payload.as_str()).unwrap();
         let updated_time = Utc::now();
-        entry.set_fetch_time(updated_time);
-        assert_eq!(entry.config.settings.len(), 1);
-        assert_eq!(entry.fetch_time, updated_time);
-        assert_eq!(entry.etag, "test-etag");
+        let updated = entry.with_fetch_time(updated_time).unwrap();
+        assert_eq!(updated.config.settings.len(), 1);
+        assert_eq!(updated.fetch_time, updated_time);
+        assert_eq!(updated.etag, "test-etag");
         assert_eq!(
-            entry.cache_str,
+            updated.cache_str,
             format!(
                 "{}\ntest-etag\n{CONFIG_JSON}",
                 updated_time.timestamp_millis()

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,6 +1,6 @@
 use log::kv::Key;
 use log::{set_max_level, Level, Log, Metadata, Record};
-use rand::distributions::{Alphanumeric, DistString};
+use rand::distr::{Alphanumeric, SampleString};
 use std::cell::RefCell;
 
 pub fn produce_mock_path() -> (String, String) {
@@ -17,7 +17,7 @@ pub fn construct_bool_json_payload(key: &str, val: bool) -> String {
 }
 
 fn rand_str(len: usize) -> String {
-    Alphanumeric.sample_string(&mut rand::thread_rng(), len)
+    Alphanumeric.sample_string(&mut rand::rng(), len)
 }
 
 pub struct PrintLog {}


### PR DESCRIPTION
### Describe the purpose of your pull request
This PR refines the synchronization mechanism in `ConfigService`. Rather than a `Mutex`, we now use atomic operations on the in-memory config data and `Semaphore` to ensure only one HTTP call is active at a time.

### Related issues (only if applicable)
- #8 

### Requirement checklist (only if applicable)
- [x] I have covered the applied changes with automated tests.
- [x] I have executed the full automated test set against my changes.
- [x] I have validated my changes against all supported platform versions.
- [x] I have read and accepted the [contribution agreement](https://github.com/configcat/legal/blob/main/contribution-agreement.md).
